### PR TITLE
Fix imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ psql -c "CREATE USER anon_test_user WITH PASSWORD 'mYy5RexGsZ' SUPERUSER;" -U po
 ### Run tests ###
 
 Check if the application is working, run unit tests:
-```python
+```bash
 chown -R postgres .
 su - postgres
 python3 test/full_test.py -v
@@ -243,17 +243,14 @@ from (
 ### How to escape/unescape complex names of objects ###
 
 ```python
-python3
-
 import json
+
 j = {"k": "_TBL.$complex#имя;@&* a'2"}
 json.dumps(j)
->>
-	'{"k": "_TBL.$complex#\\u0438\\u043c\\u044f;@&* a\'2"}'
+# >>> '{"k": "_TBL.$complex#\\u0438\\u043c\\u044f;@&* a\'2"}'
 
 s = '{"k": "_TBL.$complex#\\u0438\\u043c\\u044f;@&* a\'2"}'
 u = json.loads(s)
 print(u['k'])
->>
-	_TBL.$complex#имя;@&* a'2
+# >>> _TBL.$complex#имя;@&* a'2
 ```

--- a/common.py
+++ b/common.py
@@ -5,17 +5,16 @@ import re
 import subprocess
 import sys
 import traceback
-from enum import Enum
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from compatability import StrEnum
 
 from pkg_resources import parse_version as version
 
 
-class BasicEnum():
-    def __str__(self):
-        return self.value
-
-
-class ResultCode(BasicEnum, Enum):
+class ResultCode(StrEnum):
     DONE = 'done'
     FAIL = 'fail'
     UNKNOWN = 'unknown'
@@ -27,13 +26,13 @@ class PgAnonResult:
     result_data = None
 
 
-class VerboseOptions(BasicEnum, Enum):
+class VerboseOptions(StrEnum):
     INFO = 'info'
     DEBUG = 'debug'
     ERROR = 'error'
 
 
-class AnonMode(BasicEnum, Enum):
+class AnonMode(StrEnum):
     DUMP = 'dump'           # dump table contents to files using dictionary
     RESTORE = 'restore'     # create tables in target database and load data from files
     INIT = 'init'           # create a schema with anonymization helper functions
@@ -44,7 +43,7 @@ class AnonMode(BasicEnum, Enum):
     CREATE_DICT = 'create-dict'   # create dictionary
 
 
-class ScanMode(BasicEnum, Enum):
+class ScanMode(StrEnum):
     FULL = 'full'
     PARTIAL = 'partial'
 

--- a/common.py
+++ b/common.py
@@ -1,11 +1,12 @@
 import decimal
 import json
+import os
+import re
+import subprocess
 import sys
 import traceback
-import subprocess
-import re
-import os.path
 from enum import Enum
+
 from pkg_resources import parse_version as version
 
 

--- a/compatability.py
+++ b/compatability.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class StrEnum(str, Enum):
+    """A shorthand for a string enum required for Python versions lower than 3.11."""
+    def __str__(self):
+        return str(self.value)

--- a/create_dict.py
+++ b/create_dict.py
@@ -1,12 +1,23 @@
-import random
-import time
-from common import *
-import os
-import asyncpg
 import asyncio
 import json
+import os
+import random
+import re
+import time
+
 import aioprocessing
+import asyncpg
 import nest_asyncio
+
+from common import (
+    PgAnonResult,
+    ResultCode,
+    ScanMode,
+    chunkify,
+    exception_helper,
+    recordset_to_list,
+    setof_to_list,
+)
 
 
 async def generate_scan_objs(ctx):

--- a/dump.py
+++ b/dump.py
@@ -1,11 +1,22 @@
+import asyncio
 import hashlib
-from datetime import datetime
 import json
 import os
-import asyncpg
-import asyncio
+import re
+import subprocess
+from datetime import datetime
 from hashlib import sha256
-from common import *
+
+import asyncpg
+
+from common import (
+    AnonMode,
+    PgAnonResult,
+    ResultCode,
+    VerboseOptions,
+    exception_helper,
+    get_pg_util_version,
+)
 
 
 async def run_pg_dump(ctx, section):

--- a/pg_anon.py
+++ b/pg_anon.py
@@ -1,10 +1,27 @@
 import argparse
+import asyncio
 import logging
+import os
+import re
+import sys
+from enum import Enum
 from logging.handlers import RotatingFileHandler
-from dump import *
-from restore import *
-from create_dict import *
 
+import asyncpg
+
+from common import (
+    AnonMode,
+    PgAnonResult,
+    ResultCode,
+    ScanMode,
+    VerboseOptions,
+    check_pg_util,
+    exception_handler,
+    exception_helper,
+)
+from create_dict import create_dict
+from dump import make_dump
+from restore import make_restore, run_analyze, validate_restore
 
 PG_ANON_VERSION = '23.7.28'     # year month day
 

--- a/pg_anon.py
+++ b/pg_anon.py
@@ -4,7 +4,11 @@ import logging
 import os
 import re
 import sys
-from enum import Enum
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from compatability import StrEnum
 from logging.handlers import RotatingFileHandler
 
 import asyncpg
@@ -26,12 +30,7 @@ from restore import make_restore, run_analyze, validate_restore
 PG_ANON_VERSION = '23.7.28'     # year month day
 
 
-class BasicEnum():
-    def __str__(self):
-        return self.value
-
-
-class OutputFormat(BasicEnum, Enum):
+class OutputFormat(StrEnum):
     BINARY = 'binary'
     TEXT = 'text'
 

--- a/restore.py
+++ b/restore.py
@@ -1,9 +1,21 @@
-import os
-import asyncpg
 import asyncio
-from common import *
-import shutil
 import json
+import os
+import re
+import shutil
+import subprocess
+
+import asyncpg
+
+from common import (
+    AnonMode,
+    PgAnonResult,
+    ResultCode,
+    exception_helper,
+    get_major_version,
+    get_pg_util_version,
+    pretty_size,
+)
 
 
 async def run_pg_restore(ctx, section):

--- a/test/full_test.py
+++ b/test/full_test.py
@@ -1,10 +1,22 @@
 import copy
+import json
 import unittest
 import sys
 import os
 from decimal import Decimal
+
+import asyncpg
+
+from common import (
+    PgAnonResult,
+    ResultCode,
+    exception_helper,
+    recordset_to_list_flat,
+    to_json,
+)
+from pg_anon import Context, MainRoutine
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from pg_anon import *
 
 
 input_args = None


### PR DESCRIPTION
Fix import tables in all python modules:

1. Avoid using wildcard imports. Use PEP8 grouping style for now.
2. Split imports into groups according to PEP8
3. Sort imports in alphabetic order
4. Fix README.md codeblock headers
5. Replace custom `StrEnum` with the proposed in Python 3.11 design

I'm preparing more changes to come.
Would suggest to add an "unstable" branch to the project ("develop" or something), since making PRs to `master` is not a good practice.