### PR TITLE
[TTDB-450] Updated entrypoint and some params

### DIFF
--- a/pg_anon.py
+++ b/pg_anon.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from pg_anon import MainRoutine
+from pg_anon.pg_anon import run_pg_anon
 
 if __name__ == "__main__":
-    asyncio.run(MainRoutine().run())
+    asyncio.run(run_pg_anon())

--- a/pg_anon/__main__.py
+++ b/pg_anon/__main__.py
@@ -1,11 +1,6 @@
 import asyncio
 
-from pg_anon import MainRoutine
-
-
-def _run_pg_anon():
-    asyncio.run(MainRoutine().run())
-
+from pg_anon.pg_anon import run_pg_anon
 
 if __name__ == "__main__":
-    _run_pg_anon()
+    asyncio.run(run_pg_anon())

--- a/pg_anon/common/enums.py
+++ b/pg_anon/common/enums.py
@@ -17,9 +17,7 @@ class AnonMode(Enum):
     DUMP = "dump"  # dump table contents to files using dictionary
     RESTORE = "restore"  # create tables in target database and load data from files
     INIT = "init"  # create a schema with anonymization helper functions
-    SYNC_DATA_DUMP = (
-        "sync-data-dump"  # synchronize the contents of one or more tables (dump stage)
-    )
+    SYNC_DATA_DUMP = "sync-data-dump"  # synchronize the contents of one or more tables (dump stage)
     SYNC_DATA_RESTORE = "sync-data-restore"  # synchronize the contents of one or more tables (restore stage)
     SYNC_STRUCT_DUMP = "sync-struct-dump"  # synchronize the structure of one or more tables (dump stage)
     SYNC_STRUCT_RESTORE = "sync-struct-restore"  # synchronize the structure of one or more tables (restore stage)

--- a/pg_anon/common/utils.py
+++ b/pg_anon/common/utils.py
@@ -287,3 +287,14 @@ def get_file_name_from_path(path: str) -> str:
     """
     file_name = os.path.basename(path)
     return os.path.splitext(file_name)[0]
+
+
+def validate_exists_mode(mode: str):
+    from pg_anon.common.enums import AnonMode
+
+    try:
+        AnonMode(mode)
+    except ValueError:
+        return False
+
+    return True

--- a/pg_anon/context.py
+++ b/pg_anon/context.py
@@ -32,7 +32,9 @@ class Context:
         if args.db_user_password == "" and os.environ.get("PGPASSWORD") is not None:
             args.db_user_password = os.environ["PGPASSWORD"]
 
-        self.server_settings = SERVER_SETTINGS
+        self.server_settings = SERVER_SETTINGS.copy()
+        if self.args.application_name_suffix:
+            self.server_settings['application_name'] += '_' + self.args.application_name_suffix
 
         self.connection_params = ConnectionParams(
             host=args.db_host,
@@ -397,5 +399,12 @@ class Context:
             type=int,
             default=0,
             help="In 'view-data' mode which part of --limit rows will be displayed. By default = 0",
+        )
+        parser.add_argument(
+            "--application-name-suffix",
+            type=str,
+            default=None,
+            required=False,
+            help="Appends suffix for connection name. Just for comfortable automation",
         )
         return parser

--- a/pg_anon/pg_anon.py
+++ b/pg_anon/pg_anon.py
@@ -6,8 +6,7 @@ import sys
 import time
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
-
-import asyncpg
+from typing import Optional, List
 
 from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME
 from pg_anon.common.db_utils import check_anon_utils_db_schema_exists, create_connection
@@ -24,6 +23,17 @@ from pg_anon.restore import make_restore, run_analyze, validate_restore
 from pg_anon.version import __version__
 from pg_anon.view_data import ViewDataMode
 from pg_anon.view_fields import ViewFieldsMode
+
+
+async def run_pg_anon(cli_run_params: Optional[List[str]] = None) -> PgAnonResult:
+    """
+    Run pg_anon
+    :param cli_run_params: list of params in command line format
+    :return: result of pg_anon
+    """
+    parser = Context.get_arg_parser()
+    args = parser.parse_args(cli_run_params)
+    return await MainRoutine(args).run()
 
 
 async def make_init(ctx):
@@ -254,4 +264,4 @@ class MainRoutine:
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(MainRoutine().run())
+    loop.run_until_complete(run_pg_anon())

--- a/rest_api/api_draft.py
+++ b/rest_api/api_draft.py
@@ -1391,14 +1391,14 @@ async def stateless_view_data(request: ViewDataRequest):
                 ],
                 total_rows_count=3,
                 rows_before=[
-                    [1, 'user1001@example.com', 'user1001'],
-                    [2, 'user1002@example.com', 'user1002'],
-                    [3, 'user1003@example.com', 'user1003'],
+                    ['1', 'user1001@example.com', 'user1001'],
+                    ['2', 'user1002@example.com', 'user1002'],
+                    ['3', 'user1003@example.com', 'user1003'],
                 ],
                 rows_after=[
-                    [1, '385513d80895c4c5e19c91d1df9eacae@abc.com', 'user1001'],
-                    [2, '9f4c0c30f85b0353c4d5fe3c9cc633e3@abc.com', 'user1002'],
-                    [3, 'e4e9fe7090f5be634be77db8f86e453c@abc.com', 'user1003'],
+                    ['1', '385513d80895c4c5e19c91d1df9eacae@abc.com', 'user1001'],
+                    ['2', '9f4c0c30f85b0353c4d5fe3c9cc633e3@abc.com', 'user1002'],
+                    ['3', 'e4e9fe7090f5be634be77db8f86e453c@abc.com', 'user1003'],
                 ],
             ),
         ]

--- a/rest_api/pydantic_models.py
+++ b/rest_api/pydantic_models.py
@@ -328,15 +328,17 @@ class DbConnectionParams(BaseModel):
     user_password: str
 
 
+class StatelessRunnerRequest(BaseModel):
+    operation_id: str
+    db_connection_params: DbConnectionParams
+    webhook_status_url: str
+
+
 #############################################
 # Stateless | Scan
 #############################################
-class ScanRequest(BaseModel):
-    operation_id: str
+class ScanRequest(StatelessRunnerRequest):
     type_id: int
-
-    db_connection_params: DbConnectionParams
-    webhook_status_url: str
 
     meta_dict_contents: Dict[str, str]
     sens_dict_contents: Union[Dict[str, str], None] = None
@@ -357,11 +359,8 @@ class ScanStatusResponse(BaseModel):
 #############################################
 # Stateless | Dump
 #############################################
-class DumpRequest(BaseModel):
-    operation_id: str
+class DumpRequest(StatelessRunnerRequest):
     type_id: int
-    db_connection_params: DbConnectionParams
-    webhook_status_url: str
     sens_dict_contents: Dict[str, str]
     output_path: str
     pg_dump_path: Union[str, None] = None
@@ -425,8 +424,8 @@ class ViewDataContent(BaseModel):
     table_name: str
     field_names: List[str]
     total_rows_count: int
-    rows_before: List[List]
-    rows_after: List[List]
+    rows_before: List[List[str]]
+    rows_after: List[List[str]]
 
 
 class ViewDataResponse(BaseModel):

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -7,8 +7,6 @@ import unittest
 from decimal import Decimal
 from typing import Dict, Set
 
-import asyncpg
-
 from pg_anon import MainRoutine
 from pg_anon.common.db_utils import get_scan_fields_count, create_connection
 from pg_anon.common.dto import PgAnonResult
@@ -166,11 +164,11 @@ class BasicUnitTest:
         await DBOperations.init_db(db_conn, params.test_target_db + "_8")  # for PGAnonValidateUnitTest 05
         await db_conn.close()
 
-        sourse_db_params = copy.copy(ctx.connection_params)
-        sourse_db_params.database = params.test_source_db
+        source_db_params = copy.copy(ctx.connection_params)
+        source_db_params.database = params.test_source_db
 
         print("============> Started init_env")
-        db_conn = await create_connection(sourse_db_params)
+        db_conn = await create_connection(source_db_params)
         await DBOperations.init_env(db_conn, "init_env.sql", params.test_scale)
         await db_conn.close()
         print("<============ Finished init_env")
@@ -219,8 +217,8 @@ class BasicUnitTest:
         db_conn = await create_connection(ctx.connection_params)
         await DBOperations.init_db_once(db_conn, params.test_source_db + "_stress")
 
-        sourse_db_params = copy.copy(ctx.connection_params)
-        sourse_db_params.database = params.test_source_db + "_stress"
+        source_db_params = copy.copy(ctx.connection_params)
+        source_db_params.database = params.test_source_db + "_stress"
 
         args = parser.parse_args(
             [
@@ -243,7 +241,7 @@ class BasicUnitTest:
         await db_conn.close()
         if len(schema_exists) == 0:
             print("============> Started init_stress_env")
-            db_conn = await create_connection(sourse_db_params)
+            db_conn = await create_connection(source_db_params)
             await DBOperations.init_env(
                 db_conn, "init_stress_env.sql", params.test_scale
             )


### PR DESCRIPTION
## Added:
- `run_pg_anon` as entrypoint for all pg_anon
- CLI argument `--application-name-suffix` for comfortable automation. Influence on connection names and log names

## Updated:
- small name fixes
- starting pg_anon via entrypoint `run_pg_anon`
- response types for `/api/stateless/view-data`
