### PR TITLE
[TTDB-450] Added implementation for dump and scan

### DIFF
--- a/pg_anon/common/utils.py
+++ b/pg_anon/common/utils.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import decimal
 import hashlib
 import json
@@ -87,7 +88,9 @@ def pretty_size(bytes_v):
 
 
 def chunkify(lst, n):
-    return [lst[i::n] for i in range(n)]
+    result = [lst[i::n] for i in range(n)]
+    result = [x for x in result if x]  # clear empty lists
+    return result
 
 
 def recordset_to_list_flat(rs):
@@ -298,3 +301,29 @@ def validate_exists_mode(mode: str):
         return False
 
     return True
+
+
+def get_file_size(file_path: str) -> int:
+    if os.path.exists(file_path):
+        return os.path.getsize(file_path)
+    return 0
+
+
+def get_folder_size(folder_path: str) -> int:
+    total_size = 0
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_file = []
+        for dirpath, dirnames, filenames in os.walk(folder_path):
+            for filename in filenames:
+                file_path = os.path.join(dirpath, filename)
+                future_to_file.append(executor.submit(get_file_size, file_path))
+
+        # Собираем результаты
+        for future in concurrent.futures.as_completed(future_to_file):
+            total_size += future.result()
+
+    return total_size
+
+
+def simple_slugify(value: str):
+    return re.sub(r'\W+', '-', value).strip('-').lower()

--- a/rest_api/api_draft.py
+++ b/rest_api/api_draft.py
@@ -18,7 +18,8 @@ from rest_api.pydantic_models import Project, DbConnection, TaskStatus, DumpType
     ErrorResponse, ProjectUpdate, DbConnectionCreate, DbConnectionUpdate, DbConnectionFullCredentials, PreviewUpdate, \
     Content, ScanRequest, DumpRequest, DbConnectionParams, ViewFieldsRequest, ViewFieldsResponse, ViewFieldsContent, \
     ViewDataResponse, ViewDataRequest, ViewDataContent, DumpDeleteRequest
-from rest_api.utils import simple_slugify, get_full_dump_path
+from rest_api.utils import get_full_dump_path, delete_folder
+from pg_anon.common.utils import simple_slugify
 
 app = FastAPI(
     title='Web service for pg_anon'
@@ -1433,4 +1434,7 @@ async def stateless_dump_start(request: DumpRequest, background_tasks: Backgroun
     }
 )
 async def dump_operation_delete(request: DumpDeleteRequest, background_tasks: BackgroundTasks):
-    print(f'Delete dump dir in path {get_full_dump_path(request.path)}')
+    dump_path = get_full_dump_path(request.path)
+    print(f'Delete dump dir in path {dump_path}')
+
+    background_tasks.add_task(delete_folder, dump_path)

--- a/rest_api/enums.py
+++ b/rest_api/enums.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ScanModeHandbook(Enum):
+    FULL = 1
+    PARTIAL = 2
+
+
+class DumpModeHandbook(Enum):
+    FULL = 1
+    STRUCT = 2
+    DATA = 3
+
+
+class ResponseStatusesHandbook(Enum):
+    UNKNOWN = 1
+    SUCCESS = 2
+    ERROR = 3
+    IN_PROGRESS = 4
+    STARTING = 5

--- a/rest_api/pydantic_models.py
+++ b/rest_api/pydantic_models.py
@@ -344,6 +344,8 @@ class ScanRequest(StatelessRunnerRequest):
     sens_dict_contents: Union[Dict[str, str], None] = None
     no_sens_dict_contents: Union[Dict[str, str], None] = None
 
+    need_no_sens_dict: bool
+
     depth: Union[int, None] = None
     proc_count: Union[int, None] = None
     proc_conn_count: Union[int, None] = None
@@ -352,8 +354,8 @@ class ScanRequest(StatelessRunnerRequest):
 class ScanStatusResponse(BaseModel):
     operation_id: str
     status_id: int
-    sens_dict_content: Union[Dict[str, str], None] = None
-    no_sens_dict_content: Union[Dict[str, str], None] = None
+    sens_dict_content: Union[str, None] = None
+    no_sens_dict_content: Union[str, None] = None
 
 
 #############################################
@@ -364,6 +366,9 @@ class DumpRequest(StatelessRunnerRequest):
     sens_dict_contents: Dict[str, str]
     output_path: str
     pg_dump_path: Union[str, None] = None
+
+    proc_count: Union[int, None] = None
+    proc_conn_count: Union[int, None] = None
 
 
 class DumpStatusResponse(BaseModel):

--- a/rest_api/runners/__init__.py
+++ b/rest_api/runners/__init__.py
@@ -1,0 +1,4 @@
+from rest_api.runners.base import BaseRunner
+from rest_api.runners.dump import DumpRunner
+from rest_api.runners.scan import ScanRunner
+from rest_api.runners.init import InitRunner

--- a/rest_api/runners/base.py
+++ b/rest_api/runners/base.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from pg_anon.common.dto import PgAnonResult
+from pg_anon.common.enums import ResultCode
+from rest_api.pydantic_models import StatelessRunnerRequest
+from rest_api.utils import run_pg_anon_worker
+
+
+class BaseRunner:
+    mode: str
+    request: StatelessRunnerRequest
+    operation_id: str
+    cli_params: List[str] = None
+    result: PgAnonResult = None
+
+    def __init__(self, request: StatelessRunnerRequest):
+        self.request = request
+        self.operation_id = request.operation_id
+        self._prepare_cli_params()
+
+    def _prepare_db_credentials_cli_params(self):
+        self.cli_params.extend([
+            f'--db-host={self.request.db_connection_params.host}',
+            f'--db-port={self.request.db_connection_params.port}',
+            f'--db-user={self.request.db_connection_params.user_login}',
+            f'--db-user-password={self.request.db_connection_params.user_password}',
+            f'--db-name={self.request.db_connection_params.db_name}',
+        ])
+
+    def _prepare_verbosity_cli_params(self):
+        self.cli_params.extend([
+            "--verbose=debug",
+            "--debug",
+        ])
+
+    def _prepare_cli_params(self):
+        self.cli_params = []
+        self._prepare_db_credentials_cli_params()
+
+    async def run(self):
+        if not self.mode:
+            raise ValueError(f'Mode is not set')
+
+        result = await run_pg_anon_worker(
+            mode=self.mode,
+            operation_id=self.operation_id,
+            cli_run_params=self.cli_params
+        )
+
+        if not result or result.result_code == ResultCode.FAIL:
+            raise ValueError('Operation not completed successfully')
+
+        self.result = result
+        return self.result

--- a/rest_api/runners/dump.py
+++ b/rest_api/runners/dump.py
@@ -1,0 +1,67 @@
+from typing import List
+
+from pg_anon.common.enums import AnonMode
+from rest_api.enums import DumpModeHandbook
+from rest_api.pydantic_models import DumpRequest
+from rest_api.runners.base import BaseRunner
+from rest_api.utils import write_dictionary_contents, get_full_dump_path
+
+
+class DumpRunner(BaseRunner):
+    mode: str = AnonMode.DUMP.value
+    request: DumpRequest
+    short_dump_path: str
+    full_dump_path: str
+
+    _input_sens_dict_file_names: List[str]
+
+    def __init__(self, request: DumpRequest):
+        super().__init__(request)
+        self._set_mode()
+
+    def _set_mode(self):
+        if self.request.type_id == DumpModeHandbook.FULL:
+            self.mode = AnonMode.DUMP.value
+        elif self.request.type_id == DumpModeHandbook.STRUCT:
+            self.mode = AnonMode.SYNC_STRUCT_DUMP.value
+        elif self.request.type_id == DumpModeHandbook.DATA:
+            self.mode = AnonMode.SYNC_DATA_DUMP.value
+
+    def _prepare_dictionaries_cli_params(self):
+        self._input_sens_dict_file_names = write_dictionary_contents(self.request.sens_dict_contents)
+        self.cli_params.append(
+            f"--prepared-sens-dict-file={','.join(self._input_sens_dict_file_names)}"
+        )
+
+    def _prepare_dump_path_cli_params(self):
+        self.short_dump_path = self.request.output_path.lstrip("/")
+        self.full_dump_path = get_full_dump_path(self.short_dump_path)
+        self.cli_params.extend([
+            f'--output-dir={self.full_dump_path}',
+            '--clear-output-dir',
+        ])
+
+    def _prepare_parallelization_cli_params(self):
+        if self.request.proc_count:
+            self.cli_params.append(
+                f'--processes={self.request.proc_count}'
+            )
+
+        if self.request.proc_conn_count:
+            self.cli_params.append(
+                f'--db-connections-per-process={self.request.proc_conn_count}'
+            )
+
+    def _prepare_pg_dump_cli_params(self):
+        if self.request.pg_dump_path:
+            self.cli_params.append(
+                f'--pg-dump={self.request.pg_dump_path}'
+            )
+
+    def _prepare_cli_params(self):
+        super()._prepare_cli_params()
+        self._prepare_dictionaries_cli_params()
+        self._prepare_dump_path_cli_params()
+        self._prepare_parallelization_cli_params()
+        self._prepare_pg_dump_cli_params()
+        self._prepare_verbosity_cli_params()

--- a/rest_api/runners/init.py
+++ b/rest_api/runners/init.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from pg_anon.common.enums import AnonMode
+from rest_api.enums import DumpModeHandbook
+from rest_api.pydantic_models import DumpRequest
+from rest_api.runners.base import BaseRunner
+from rest_api.utils import write_dictionary_contents, get_full_dump_path
+
+
+class InitRunner(BaseRunner):
+    mode: str = AnonMode.INIT.value

--- a/rest_api/runners/scan.py
+++ b/rest_api/runners/scan.py
@@ -1,0 +1,77 @@
+from typing import Optional
+
+from pg_anon.common.enums import AnonMode, ScanMode
+from rest_api.enums import ScanModeHandbook
+from rest_api.pydantic_models import ScanRequest
+from rest_api.runners.base import BaseRunner
+from rest_api.utils import write_dictionary_contents
+
+
+class ScanRunner(BaseRunner):
+    mode: str = AnonMode.CREATE_DICT.value
+    request: ScanRequest
+    output_sens_dict_file_name: str
+    output_no_sens_dict_file_name: Optional[str] = None
+
+    def _prepare_dictionaries_cli_params(self):
+        input_meta_dict_file_names = write_dictionary_contents(self.request.meta_dict_contents)
+
+        input_sens_dict_file_names = None
+        if self.request.sens_dict_contents:
+            input_sens_dict_file_names = write_dictionary_contents(self.request.sens_dict_contents)
+
+        input_no_sens_dict_file_names = None
+        if self.request.no_sens_dict_contents:
+            input_no_sens_dict_file_names = write_dictionary_contents(self.request.no_sens_dict_contents)
+
+        self.output_sens_dict_file_name = f'/tmp/output_sens_dict_{self.request.operation_id}.py'
+
+        self.cli_params.extend([
+            f"--meta-dict-file={','.join(input_meta_dict_file_names)}",
+            f"--output-sens-dict-file={self.output_sens_dict_file_name}",
+        ])
+
+        if self.request.need_no_sens_dict:
+            self.output_no_sens_dict_file_name = f'/tmp/output_no_sens_dict_{self.request.operation_id}.py'
+            self.cli_params.append(
+                f"--output-no-sens-dict-file={self.output_no_sens_dict_file_name}",
+            )
+
+        if input_sens_dict_file_names:
+            self.cli_params.append(
+                f"--prepared-sens-dict-file={','.join(input_sens_dict_file_names)}"
+            )
+
+        if input_no_sens_dict_file_names:
+            self.cli_params.append(
+                f"--prepared-no-sens-dict-file={','.join(input_no_sens_dict_file_names)}"
+            )
+
+    def _prepare_parallelization_cli_params(self):
+        if self.request.proc_count:
+            self.cli_params.append(
+                f'--processes={self.request.proc_count}'
+            )
+
+        if self.request.proc_conn_count:
+            self.cli_params.append(
+                f'--db-connections-per-process={self.request.proc_conn_count}'
+            )
+
+    def _prepare_scan_mode_cli_params(self):
+        if self.request.type_id == ScanModeHandbook.PARTIAL and self.request.depth:
+            self.cli_params.extend([
+                f'--scan-mode={ScanMode.PARTIAL.value}',
+                f'--scan-partial-rows={self.request.depth}',
+            ])
+        else:
+            self.cli_params.append(
+                f'--scan-mode={ScanMode.FULL.value}'
+            )
+
+    def _prepare_cli_params(self):
+        super()._prepare_cli_params()
+        self._prepare_dictionaries_cli_params()
+        self._prepare_parallelization_cli_params()
+        self._prepare_scan_mode_cli_params()
+        self._prepare_verbosity_cli_params()

--- a/rest_api/utils.py
+++ b/rest_api/utils.py
@@ -1,12 +1,94 @@
+import asyncio
 import os
-import re
+import shutil
+import uuid
+from typing import List, Optional, Dict
 
-DUMP_STORAGE_BASE_DIR = '/some/dumps'
+import aioprocessing
 
+from pg_anon.common.dto import PgAnonResult
+from pg_anon.common.utils import validate_exists_mode, simple_slugify
+from pg_anon.pg_anon import run_pg_anon
 
-def simple_slugify(value: str):
-    return re.sub(r'\W+', '-', value).strip('-').lower()
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+DUMP_STORAGE_BASE_DIR = os.path.join(BASE_DIR, 'output')
 
 
 def get_full_dump_path(dump_path: str) -> str:
-    return os.path.join(DUMP_STORAGE_BASE_DIR, dump_path)
+    return os.path.join(DUMP_STORAGE_BASE_DIR, dump_path.lstrip("/"))
+
+
+def write_dictionary_contents(dictionary_contents: Dict[str, str]):
+    file_names = []
+
+    for dict_name, content in dictionary_contents.items():
+        file_name = f'/tmp/{simple_slugify(dict_name)}-{uuid.uuid4()}.py'
+        with open(file_name, "w") as out_file:
+            out_file.write(content)
+
+        file_names.append(file_name)
+
+    return file_names
+
+
+def read_dictionary_contents(file_path: str) -> str:
+    with open(file_path, "r") as dictionary_file:
+        data = dictionary_file.read()
+
+    return data
+
+
+def delete_folder(folder_path: str):
+    try:
+        shutil.rmtree(folder_path)
+        print(f"Folder {folder_path} deleted successfully.")
+    except Exception as e:
+        print(f"Error deleting folder {folder_path}: {str(e)}")
+
+
+def run_pg_anon_subprocess_wrapper(queue: aioprocessing.AioQueue, cli_run_params: List[str]):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    try:
+        # Выполняем асинхронную функцию внутри нового event loop
+        result = loop.run_until_complete(
+            run_pg_anon(cli_run_params)
+        )
+        queue.put(result)
+    except Exception as ex:
+        print(ex)
+    finally:
+        queue.put(None)  # Завершаем процесс
+        queue.close()
+        loop.close()
+
+
+async def run_pg_anon_worker(mode: str, operation_id: str, cli_run_params: List[str]) -> Optional[PgAnonResult]:
+    if not validate_exists_mode(mode):
+        raise ValueError(f'Invalid mode: {mode}')
+
+    application_name_suffix = f'worker__{mode}__{operation_id}'
+    cli_run_params.extend([
+        f'--mode={mode}',
+        f'--application-name-suffix={application_name_suffix}',
+    ])
+
+    queue = aioprocessing.AioQueue()
+
+    p = aioprocessing.AioProcess(
+        name=f"pg_anon_{application_name_suffix}",
+        target=run_pg_anon_subprocess_wrapper,
+        args=(queue, cli_run_params),
+    )
+    p.start()
+
+    result = None
+    while True:
+        coro_result = await queue.coro_get()
+        if coro_result is None:
+            break
+        result = coro_result
+    await p.coro_join()
+
+    return result


### PR DESCRIPTION
## Added:
- `POST` `/api/stateless/scan` - for scanning
- `POST` `/api/stateless/dump` - for creating dump
- `DELETE` `/api/stateless/dump` - for deleting dump

## Updated:
- fixed hash randomization by `hash()` in multiprocessing in DUMP operation
- added correct exit in case of failed queries
- updated log names
- added check existing schema `anon_funcs` for SCAN operation