### PR TITLE
[TTDB-394] Fixes for multiprocessing and `view-data` mode

### DIFF
--- a/pg_anon.py
+++ b/pg_anon.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from pg_anon import MainRoutine
+from pg_anon.pg_anon import run_pg_anon
 
 if __name__ == "__main__":
-    asyncio.run(MainRoutine().run())
+    asyncio.run(run_pg_anon())

--- a/pg_anon/__main__.py
+++ b/pg_anon/__main__.py
@@ -1,11 +1,6 @@
 import asyncio
 
-from pg_anon import MainRoutine
-
-
-def _run_pg_anon():
-    asyncio.run(MainRoutine().run())
-
+from pg_anon.pg_anon import run_pg_anon
 
 if __name__ == "__main__":
-    _run_pg_anon()
+    asyncio.run(run_pg_anon())

--- a/pg_anon/common/constants.py
+++ b/pg_anon/common/constants.py
@@ -1,1 +1,9 @@
 ANON_UTILS_DB_SCHEMA_NAME = 'anon_funcs'
+
+SERVER_SETTINGS = {
+    "application_name": "pg_anon",
+    "statement_timeout": "0",
+    "lock_timeout": "0",
+    "idle_in_transaction_session_timeout": "0",
+    "idle_session_timeout": "0",
+}

--- a/pg_anon/common/db_queries.py
+++ b/pg_anon/common/db_queries.py
@@ -8,6 +8,13 @@ def get_query_limit(limit: int) -> str:
     return f"LIMIT {limit}" if limit is not None and limit > 0 else ""
 
 
+def get_query_count(schema_name: str, table_name: str) -> str:
+    return f"""
+        SELECT count(*)
+        FROM \"{schema_name}\".\"{table_name}\"
+    """
+
+
 def get_query_get_scan_fields(limit: int = None, count_only: bool = False):
     if not count_only:
         fields = f"""

--- a/pg_anon/common/db_utils.py
+++ b/pg_anon/common/db_utils.py
@@ -4,7 +4,7 @@ import asyncpg
 from asyncpg import Connection
 
 from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME, SERVER_SETTINGS
-from pg_anon.common.db_queries import get_query_get_scan_fields
+from pg_anon.common.db_queries import get_query_get_scan_fields, get_query_count
 from pg_anon.common.dto import FieldInfo, ConnectionParams
 
 
@@ -102,6 +102,22 @@ async def get_fields_list(connection_params: ConnectionParams, table_schema: str
     )
     await db_conn.close()
     return fields_list
+
+
+async def get_rows_count(connection_params: ConnectionParams, schema_name: str, table_name: str, server_settings: Dict = SERVER_SETTINGS) -> int:
+    """
+    Get rows count in table
+    :param connection_params: Required connection parameters such as host, login, password and etc.
+    :param schema_name: Schema name
+    :param table_name: Table name
+    :param server_settings: Optional server settings for new connection. Can consists of timeout settings, application name and etc.
+    :return: rows count in table
+    """
+    query = get_query_count(schema_name=schema_name, table_name=table_name)
+    db_conn = await create_connection(connection_params, server_settings=server_settings)
+    count = await db_conn.fetchval(query)
+    await db_conn.close()
+    return count
 
 
 async def exec_data_scan_func_query(connection: Connection, scan_func: str, value, field_info: FieldInfo) -> bool:

--- a/pg_anon/common/db_utils.py
+++ b/pg_anon/common/db_utils.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 import asyncpg
-from asyncpg import Connection
+from asyncpg import Connection, Pool
 
 from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME, SERVER_SETTINGS
 from pg_anon.common.db_queries import get_query_get_scan_fields, get_query_count
@@ -15,7 +15,7 @@ async def create_connection(connection_params: ConnectionParams, server_settings
     )
 
 
-async def create_pool(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS, min_size: int = 10, max_size: int = 10) -> Connection:
+async def create_pool(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS, min_size: int = 10, max_size: int = 10) -> Pool:
     return await asyncpg.create_pool(
         **connection_params.as_dict(),
         server_settings=server_settings,

--- a/pg_anon/common/db_utils.py
+++ b/pg_anon/common/db_utils.py
@@ -3,12 +3,38 @@ from typing import Dict, List
 import asyncpg
 from asyncpg import Connection
 
-from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME
+from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME, SERVER_SETTINGS
 from pg_anon.common.db_queries import get_query_get_scan_fields
-from pg_anon.common.dto import FieldInfo
+from pg_anon.common.dto import FieldInfo, ConnectionParams
 
 
-async def check_anon_utils_db_schema_exists(connection_params: Dict, server_settings: Dict = None) -> bool:
+async def create_connection(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS) -> Connection:
+    return await asyncpg.connect(
+        **connection_params.as_dict(),
+        server_settings=server_settings,
+    )
+
+
+async def create_pool(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS, min_size: int = 10, max_size: int = 10) -> Connection:
+    return await asyncpg.create_pool(
+        **connection_params.as_dict(),
+        server_settings=server_settings,
+        min_size=min_size,
+        max_size=max_size,
+    )
+
+
+async def check_db_connection(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS) -> bool:
+    try:
+        db_conn = await create_connection(connection_params, server_settings=server_settings)
+        await db_conn.close()
+    except Exception as ex:
+        return False
+
+    return True
+
+
+async def check_anon_utils_db_schema_exists(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS) -> bool:
     """
     Checks exists db schema what consists predefined anonymization utils
     :param connection_params: Required connection parameters such as host, login, password and etc.
@@ -19,13 +45,13 @@ async def check_anon_utils_db_schema_exists(connection_params: Dict, server_sett
     select exists (select schema_name FROM information_schema.schemata where "schema_name" = '{ANON_UTILS_DB_SCHEMA_NAME}');
     """
 
-    db_conn = await asyncpg.connect(**connection_params, server_settings=server_settings)
+    db_conn = await create_connection(connection_params, server_settings=server_settings)
     exists = await db_conn.fetchval(query)
     await db_conn.close()
     return exists
 
 
-async def get_scan_fields_list(connection_params: Dict, server_settings: Dict = None, limit: int = None) -> List:
+async def get_scan_fields_list(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS, limit: int = None) -> List:
     """
     Get fields list for scan sensitive data
     :param connection_params: Required connection parameters such as host, login, password and etc.
@@ -35,13 +61,13 @@ async def get_scan_fields_list(connection_params: Dict, server_settings: Dict = 
     """
     query = get_query_get_scan_fields(limit=limit)
 
-    db_conn = await asyncpg.connect(**connection_params, server_settings=server_settings)
+    db_conn = await create_connection(connection_params, server_settings=server_settings)
     fields_list = await db_conn.fetch(query)
     await db_conn.close()
     return fields_list
 
 
-async def get_scan_fields_count(connection_params: Dict, server_settings: Dict = None) -> int:
+async def get_scan_fields_count(connection_params: ConnectionParams, server_settings: Dict = SERVER_SETTINGS) -> int:
     """
     Get count of fields for scan sensitive data
     :param connection_params: Required connection parameters such as host, login, password and etc.
@@ -50,13 +76,13 @@ async def get_scan_fields_count(connection_params: Dict, server_settings: Dict =
     """
     query = get_query_get_scan_fields(count_only=True)
 
-    db_conn = await asyncpg.connect(**connection_params, server_settings=server_settings)
+    db_conn = await create_connection(connection_params, server_settings=server_settings)
     count = await db_conn.fetchval(query)
     await db_conn.close()
     return count
 
 
-async def get_fields_list(connection_params: Dict, table_schema: str, table_name: str, server_settings: Dict = None) -> List:
+async def get_fields_list(connection_params: ConnectionParams, table_schema: str, table_name: str, server_settings: Dict = SERVER_SETTINGS) -> List:
     """
     Get fields list for dump
     :param connection_params: Required connection parameters such as host, login, password and etc.
@@ -65,7 +91,7 @@ async def get_fields_list(connection_params: Dict, table_schema: str, table_name
     :param server_settings: Optional server settings for new connection. Can consists of timeout settings, application name and etc.
     :return: fields list for dump
     """
-    db_conn = await asyncpg.connect(**connection_params, server_settings=server_settings)
+    db_conn = await create_connection(connection_params, server_settings=server_settings)
     fields_list = await db_conn.fetch(
         """
             SELECT column_name, udt_name FROM information_schema.columns

--- a/pg_anon/common/dto.py
+++ b/pg_anon/common/dto.py
@@ -22,7 +22,7 @@ class FieldInfo:
     obj_id: str
     tbl_id: str
     rule: Optional[Callable] = None  # uses for --mode=create-dict with --prepared-sens-dict-file
-    dict_file_name: Optional[List] = None  # uses for --mode=view-fields
+    dict_file_name: Optional[str] = None  # uses for --mode=view-fields
 
 
 class ConnectionParams:

--- a/pg_anon/common/dto.py
+++ b/pg_anon/common/dto.py
@@ -23,3 +23,45 @@ class FieldInfo:
     tbl_id: str
     rule: Optional[Callable] = None  # uses for --mode=create-dict with --prepared-sens-dict-file
     dict_file_name: Optional[List] = None  # uses for --mode=view-fields
+
+
+class ConnectionParams:
+    host: str
+    database: str
+    port: int
+    user: str
+
+    password: Optional[str] = None
+    passfile: Optional[str] = None
+
+    ssl_cert_file: Optional[str] = None
+    ssl_key_file: Optional[str] = None
+    ssl_ca_file: Optional[str] = None
+
+    ssl: Optional[str] = None
+    ssl_min_protocol_version: Optional[str] = None
+
+    def __init__(self, host: str, port: int, database: str, user: str,
+                 password: Optional[str] = None, passfile: Optional[str] = None,
+                 ssl_cert_file: Optional[str] = None, ssl_key_file: Optional[str] = None,
+                 ssl_ca_file: Optional[str] = None):
+        self.host = host
+        self.port = port
+        self.database = database
+        self.user = user
+
+        if password:
+            self.password = password
+
+        if passfile:
+            self.passfile = passfile
+
+        if ssl_cert_file or ssl_key_file or ssl_ca_file:
+            self.ssl = "on"
+            self.ssl_min_protocol_version = "TLSv1.2"
+            self.ssl_cert_file = ssl_cert_file
+            self.ssl_key_file = ssl_key_file
+            self.ssl_ca_file = ssl_ca_file
+
+    def as_dict(self) -> dict:
+        return self.__dict__

--- a/pg_anon/common/enums.py
+++ b/pg_anon/common/enums.py
@@ -17,9 +17,7 @@ class AnonMode(Enum):
     DUMP = "dump"  # dump table contents to files using dictionary
     RESTORE = "restore"  # create tables in target database and load data from files
     INIT = "init"  # create a schema with anonymization helper functions
-    SYNC_DATA_DUMP = (
-        "sync-data-dump"  # synchronize the contents of one or more tables (dump stage)
-    )
+    SYNC_DATA_DUMP = "sync-data-dump"  # synchronize the contents of one or more tables (dump stage)
     SYNC_DATA_RESTORE = "sync-data-restore"  # synchronize the contents of one or more tables (restore stage)
     SYNC_STRUCT_DUMP = "sync-struct-dump"  # synchronize the structure of one or more tables (dump stage)
     SYNC_STRUCT_RESTORE = "sync-struct-restore"  # synchronize the structure of one or more tables (restore stage)

--- a/pg_anon/common/utils.py
+++ b/pg_anon/common/utils.py
@@ -240,7 +240,7 @@ async def get_dump_query(ctx, table_schema: str, table_name: str, table_rule,
         else:
             # the table is transferred with the specific fields for anonymization
             fields_list = await get_fields_list(
-                connection_params=ctx.conn_params,
+                connection_params=ctx.connection_params,
                 server_settings=ctx.server_settings,
                 table_schema=table_schema,
                 table_name=table_name

--- a/pg_anon/common/utils.py
+++ b/pg_anon/common/utils.py
@@ -287,3 +287,14 @@ def get_file_name_from_path(path: str) -> str:
     """
     file_name = os.path.basename(path)
     return os.path.splitext(file_name)[0]
+
+
+def validate_exists_mode(mode: str):
+    from pg_anon.common.enums import AnonMode
+
+    try:
+        AnonMode(mode)
+    except ValueError:
+        return False
+
+    return True

--- a/pg_anon/common/utils.py
+++ b/pg_anon/common/utils.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import decimal
 import hashlib
 import json
@@ -87,7 +88,9 @@ def pretty_size(bytes_v):
 
 
 def chunkify(lst, n):
-    return [lst[i::n] for i in range(n)]
+    result = [lst[i::n] for i in range(n)]
+    result = [x for x in result if x]  # clear empty lists
+    return result
 
 
 def recordset_to_list_flat(rs):
@@ -298,3 +301,29 @@ def validate_exists_mode(mode: str):
         return False
 
     return True
+
+
+def get_file_size(file_path: str) -> int:
+    if os.path.exists(file_path):
+        return os.path.getsize(file_path)
+    return 0
+
+
+def get_folder_size(folder_path: str) -> int:
+    total_size = 0
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_file = []
+        for dirpath, dirnames, filenames in os.walk(folder_path):
+            for filename in filenames:
+                file_path = os.path.join(dirpath, filename)
+                future_to_file.append(executor.submit(get_file_size, file_path))
+
+        # Собираем результаты
+        for future in concurrent.futures.as_completed(future_to_file):
+            total_size += future.result()
+
+    return total_size
+
+
+def simple_slugify(value: str):
+    return re.sub(r'\W+', '-', value).strip('-').lower()

--- a/pg_anon/context.py
+++ b/pg_anon/context.py
@@ -2,7 +2,8 @@ import argparse
 import os
 from typing import Dict, Optional
 
-from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME
+from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME, SERVER_SETTINGS
+from pg_anon.common.dto import ConnectionParams
 from pg_anon.common.enums import VerboseOptions, AnonMode, ScanMode
 from pg_anon.common.utils import (
     exception_handler,
@@ -31,41 +32,19 @@ class Context:
         if args.db_user_password == "" and os.environ.get("PGPASSWORD") is not None:
             args.db_user_password = os.environ["PGPASSWORD"]
 
-        self.server_settings = {
-            "application_name": "pg_anon",
-            "statement_timeout": "0",
-            "lock_timeout": "0",
-            "idle_in_transaction_session_timeout": "0",
-            "idle_session_timeout": "0",
-        }
+        self.server_settings = SERVER_SETTINGS
 
-        self.conn_params = {
-            "host": args.db_host,
-            "database": args.db_name,
-            "port": args.db_port,
-            "user": args.db_user,
-        }
-
-        if args.db_passfile != "":
-            self.conn_params.update({"passfile": args.db_passfile})
-
-        if args.db_user_password != "":
-            self.conn_params.update({"password": args.db_user_password})
-
-        if (
-            args.db_ssl_cert_file != ""
-            or args.db_ssl_key_file != ""
-            or args.db_ssl_ca_file != ""
-        ):
-            self.conn_params.update(
-                {
-                    "ssl": "on",
-                    "ssl_min_protocol_version": "TLSv1.2",
-                    "ssl_cert_file": args.db_ssl_cert_file,
-                    "ssl_key_file": args.db_ssl_key_file,
-                    "ssl_ca_file": args.db_ssl_ca_file,
-                }
-            )
+        self.connection_params = ConnectionParams(
+            host=args.db_host,
+            database=args.db_name,
+            port=args.db_port,
+            user=args.db_user,
+            passfile=args.db_passfile,
+            password=args.db_user_password,
+            ssl_cert_file=args.db_ssl_cert_file,
+            ssl_key_file=args.db_ssl_key_file,
+            ssl_ca_file=args.db_ssl_ca_file,
+        )
 
     def _check_meta_dict_types(self, meta_dict: Dict):
         """

--- a/pg_anon/context.py
+++ b/pg_anon/context.py
@@ -32,7 +32,9 @@ class Context:
         if args.db_user_password == "" and os.environ.get("PGPASSWORD") is not None:
             args.db_user_password = os.environ["PGPASSWORD"]
 
-        self.server_settings = SERVER_SETTINGS
+        self.server_settings = SERVER_SETTINGS.copy()
+        if self.args.application_name_suffix:
+            self.server_settings['application_name'] += '_' + self.args.application_name_suffix
 
         self.connection_params = ConnectionParams(
             host=args.db_host,
@@ -397,5 +399,12 @@ class Context:
             type=int,
             default=0,
             help="In 'view-data' mode which part of --limit rows will be displayed. By default = 0",
+        )
+        parser.add_argument(
+            "--application-name-suffix",
+            type=str,
+            default=None,
+            required=False,
+            help="Appends suffix for connection name. Just for comfortable automation",
         )
         return parser

--- a/pg_anon/create_dict.py
+++ b/pg_anon/create_dict.py
@@ -513,8 +513,8 @@ def process_impl(name: str, ctx: Context, queue: AioQueue, fields_info_chunk: Li
             await asyncio.wait(tasks)
         await pool.close()
 
-    nest_asyncio.apply()
     loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     try:
         loop.run_until_complete(run())

--- a/pg_anon/dump.py
+++ b/pg_anon/dump.py
@@ -253,7 +253,7 @@ def process_dump_impl(name: str, ctx: Context, queue: AioQueue, query_tasks: Lis
 
                 ctx.logger.debug(f"================> Process [{name}] Adding new task into pool [{idx + 1}/{query_tasks_count}]")
                 task_res = loop.create_task(
-                    dump_by_query(ctx, pool, query, transaction_snapshot_id, file_name)
+                    dump_by_query(ctx, pool, query, transaction_snapshot_id, file_name, name)
                 )
 
                 tasks.add(task_res)

--- a/pg_anon/dump.py
+++ b/pg_anon/dump.py
@@ -154,9 +154,9 @@ async def dump_by_query(ctx: Context, pool: Pool, query: str, transaction_snapsh
             ctx.logger.debug(f"Process [{process_name}] Task [{task_id}] Pool closed!")
 
         error_message = "Something went wrong"
-        if not compress_is_complete:
+        if not dump_is_complete:
             error_message = f"Can't execute query: {query}"
-        elif not dump_is_complete:
+        elif not compress_is_complete:
             error_message = f"Can't compress file: {binary_output_file_path}"
 
         ctx.logger.debug(f"Process [{process_name}] Task [{task_id}] Error: {error_message}")

--- a/pg_anon/dump.py
+++ b/pg_anon/dump.py
@@ -254,11 +254,11 @@ def process_dump_impl(name: str, ctx: Context, queue: AioQueue, query_tasks: Lis
         ctx.logger.error(f"================> Process [{name}]: {ex}")
         raise ex
     finally:
-        ctx.logger.error(f"================> Process [{name}] closing")
+        ctx.logger.info(f"================> Process [{name}] closing")
         loop.close()
         queue.put(None)  # Shut down the worker
         queue.close()
-        ctx.logger.error(f"================> Process [{name}] closed")
+        ctx.logger.info(f"================> Process [{name}] closed")
 
 
 async def make_dump_impl(ctx: Context, db_conn: Connection, transaction_snapshot_id: str):

--- a/pg_anon/dump.py
+++ b/pg_anon/dump.py
@@ -239,8 +239,8 @@ def process_dump_impl(name: str, ctx: Context, queue: AioQueue, query_tasks: Lis
 
         await pool.close()
 
-    nest_asyncio.apply()
     loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     try:
         loop.run_until_complete(run())

--- a/pg_anon/pg_anon.py
+++ b/pg_anon/pg_anon.py
@@ -6,8 +6,7 @@ import sys
 import time
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
-
-import asyncpg
+from typing import Optional, List
 
 from pg_anon.common.constants import ANON_UTILS_DB_SCHEMA_NAME
 from pg_anon.common.db_utils import check_anon_utils_db_schema_exists, create_connection
@@ -24,6 +23,17 @@ from pg_anon.restore import make_restore, run_analyze, validate_restore
 from pg_anon.version import __version__
 from pg_anon.view_data import ViewDataMode
 from pg_anon.view_fields import ViewFieldsMode
+
+
+async def run_pg_anon(cli_run_params: Optional[List[str]] = None) -> PgAnonResult:
+    """
+    Run pg_anon
+    :param cli_run_params: list of params in command line format
+    :return: result of pg_anon
+    """
+    parser = Context.get_arg_parser()
+    args = parser.parse_args(cli_run_params)
+    return await MainRoutine(args).run()
 
 
 async def make_init(ctx):
@@ -254,4 +264,4 @@ class MainRoutine:
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(MainRoutine().run())
+    loop.run_until_complete(run_pg_anon())

--- a/pg_anon/view_data.py
+++ b/pg_anon/view_data.py
@@ -53,7 +53,7 @@ class ViewDataMode:
             field_name = field["column_name"]
             self.raw_field_names.append(field_name)
 
-            if field_name in self.table_rule["fields"]:
+            if self.table_rule and field_name in self.table_rule["fields"]:
                 self.field_names.append('* ' + field_name)
             else:
                 self.field_names.append(field_name)

--- a/pg_anon/view_data.py
+++ b/pg_anon/view_data.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 import asyncpg
 from prettytable import PrettyTable, SINGLE_BORDER
 
-from pg_anon.common.db_utils import get_fields_list
+from pg_anon.common.db_utils import get_fields_list, create_connection
 from pg_anon.common.dto import PgAnonResult
 from pg_anon.common.enums import ResultCode
 from pg_anon.common.utils import exception_helper, get_dump_query, get_dict_rule_for_table
@@ -37,7 +37,7 @@ class ViewDataMode:
         Get field names and all fields for view-data mode
         """
         fields_list = await get_fields_list(
-            connection_params=self.context.conn_params,
+            connection_params=self.context.connection_params,
             server_settings=self.context.server_settings,
             table_schema=self._schema_name,
             table_name=self._table_name
@@ -49,7 +49,7 @@ class ViewDataMode:
             else:
                 self.field_names.append(field_name)
 
-        db_conn = await asyncpg.connect(**self.context.conn_params)
+        db_conn = await create_connection(self.context.connection_params)
         table_result = await db_conn.fetch(self.query)
         self.fields = [[record[field["column_name"]] for field in fields_list] for record in table_result]
         await db_conn.close()

--- a/pg_anon/view_data.py
+++ b/pg_anon/view_data.py
@@ -25,7 +25,7 @@ class ViewDataMode:
     raw_query: Optional[str] = None
     raw_data: Optional[List[List[str]]] = None
     table: PrettyTable = None
-    _need_raw_data: bool = True
+    _need_raw_data: bool = False
 
     def __init__(self, context: Context, need_raw_data: bool = False):
         self.context = context

--- a/pg_anon/view_data.py
+++ b/pg_anon/view_data.py
@@ -1,10 +1,9 @@
 import json
-from typing import List, Dict
+from typing import List, Dict, Optional
 
-import asyncpg
 from prettytable import PrettyTable, SINGLE_BORDER
 
-from pg_anon.common.db_utils import get_fields_list, create_connection
+from pg_anon.common.db_utils import get_fields_list, create_connection, get_rows_count
 from pg_anon.common.dto import PgAnonResult
 from pg_anon.common.enums import ResultCode
 from pg_anon.common.utils import exception_helper, get_dump_query, get_dict_rule_for_table
@@ -18,19 +17,27 @@ class ViewDataMode:
     _schema_name: str
     _table_name: str
     table_rule: Dict
-    query: str
+    raw_field_names: List[str] = None
     field_names: List[str] = None
-    fields: List[List] = None
+    rows_count: int = 0
+    query: str
+    data: List[List[str]] = None
+    raw_query: Optional[str] = None
+    raw_data: Optional[List[List[str]]] = None
     table: PrettyTable = None
+    _need_raw_data: bool = True
 
-    def __init__(self, context: Context):
+    def __init__(self, context: Context, need_raw_data: bool = False):
         self.context = context
         self._limit = context.args.limit
         self._offset = context.args.offset
         self._schema_name = context.args.schema_name
         self._table_name = context.args.table_name
         self.field_names = []
-        self.fields = []
+        self.raw_field_names = []
+        self.data = []
+        self.raw_data = []
+        self._need_raw_data = need_raw_data
 
     async def _get_fields_for_view(self) -> None:
         """
@@ -44,26 +51,40 @@ class ViewDataMode:
         )
         for field in fields_list:
             field_name = field["column_name"]
+            self.raw_field_names.append(field_name)
+
             if field_name in self.table_rule["fields"]:
                 self.field_names.append('* ' + field_name)
             else:
                 self.field_names.append(field_name)
 
-        db_conn = await create_connection(self.context.connection_params)
-        table_result = await db_conn.fetch(self.query)
-        self.fields = [[record[field["column_name"]] for field in fields_list] for record in table_result]
+    async def _get_data_for_view(self, query: str) -> List[List[str]]:
+        db_conn = await create_connection(self.context.connection_params, server_settings=self.context.server_settings)
+        table_result = await db_conn.fetch(query)
         await db_conn.close()
+        
+        data = [[record[field_name] for field_name in self.raw_field_names] for record in table_result]
+        return data
+
+    async def get_rows_count(self):
+        self.rows_count = await get_rows_count(
+            connection_params=self.context.connection_params,
+            server_settings=self.context.server_settings,
+            schema_name=self._schema_name,
+            table_name=self._table_name
+        )
+        return self.rows_count
 
     def _prepare_table(self) -> None:
         self.table = PrettyTable(self.field_names)
         self.table.set_style(SINGLE_BORDER)
-        for row in self.fields:
+        for row in self.data:
             self.table.add_row(row)
 
     def _prepare_json(self) -> None:
         result = {field: [] for field in self.field_names}
 
-        for field_values in self.fields:
+        for field_values in self.data:
             for field, value in zip(self.field_names, field_values):
                 result[field].append(value)
 
@@ -74,8 +95,13 @@ class ViewDataMode:
         await self._get_fields_for_view()
         if not self.field_names:
             raise ValueError("No field names for view!")
-        if not self.fields:
+
+        self.data = await self._get_data_for_view(self.query)
+        if not self.data:
             raise ValueError("Not found fields for view!")
+
+        if self._need_raw_data:
+            self.raw_data = await self._get_data_for_view(self.raw_query)
 
         if self.context.args.json:
             self._prepare_json()
@@ -83,6 +109,34 @@ class ViewDataMode:
         else:
             self._prepare_table()
             print(self.table)
+
+    async def _prepare_queries(self):
+        files = {}
+        included_objs = []
+        excluded_objs = []
+
+        query_without_limit = await get_dump_query(
+            ctx=self.context,
+            table_schema=self._schema_name,
+            table_name=self._table_name,
+            table_rule=self.table_rule,
+            files=files,
+            included_objs=included_objs,
+            excluded_objs=excluded_objs
+        )
+        self.query = query_without_limit + f" LIMIT {self._limit} OFFSET {self._offset}"
+
+        if self._need_raw_data:
+            query_without_limit = await get_dump_query(
+                ctx=self.context,
+                table_schema=self._schema_name,
+                table_name=self._table_name,
+                table_rule=None,
+                files=files,
+                included_objs=included_objs,
+                excluded_objs=excluded_objs
+            )
+            self.raw_query = query_without_limit + f" LIMIT {self._limit} OFFSET {self._offset}"
 
     async def run(self) -> PgAnonResult:
         result = PgAnonResult()
@@ -107,27 +161,8 @@ class ViewDataMode:
             table=self._table_name,
         )
 
-        files = {}
-        included_objs = []
-        excluded_objs = []
-
         try:
-            query_without_limit = await get_dump_query(
-                ctx=self.context,
-                table_schema=self._schema_name,
-                table_name=self._table_name,
-                table_rule=self.table_rule,
-                files=files,
-                included_objs=included_objs,
-                excluded_objs=excluded_objs
-            )
-            self.query = query_without_limit + f" LIMIT {self._limit} OFFSET {self._offset}"
-        except:
-            self.context.logger.error("<------------- view_fields failed\n" + exception_helper())
-            result.result_code = ResultCode.FAIL
-            return result
-
-        try:
+            await self._prepare_queries()
             await self._output_fields()
         except:
             self.context.logger.error("<------------- view_fields failed\n" + exception_helper())

--- a/pg_anon/view_fields.py
+++ b/pg_anon/view_fields.py
@@ -19,6 +19,7 @@ class ViewFieldsMode:
     table: PrettyTable = None
     json: str = None
     fields_cut_by_limits: bool = False
+    empty_data_filler: str = '---'
 
     def __init__(self, context: Context):
         self.context = context
@@ -115,8 +116,8 @@ class ViewFieldsMode:
                     continue
 
             if not self.context.args.view_only_sensitive_fields:
-                field.rule = '---'
-                field.dict_file_name = '---'
+                field.rule = self.empty_data_filler
+                field.dict_file_name = self.empty_data_filler
                 fields_with_find_rules.append(field)
 
         self.fields = fields_with_find_rules

--- a/pg_anon/view_fields.py
+++ b/pg_anon/view_fields.py
@@ -66,7 +66,7 @@ class ViewFieldsMode:
         :return: list of fields for view mode
         """
         fields_list = await get_scan_fields_list(
-            connection_params=self.context.conn_params,
+            connection_params=self.context.connection_params,
             server_settings=self.context.server_settings,
             limit=self._processing_fields_limit
         )
@@ -81,7 +81,7 @@ class ViewFieldsMode:
 
     async def _make_notice_fields_cut_by_limits(self):
         fields_count = await get_scan_fields_count(
-            connection_params=self.context.conn_params,
+            connection_params=self.context.connection_params,
             server_settings=self.context.server_settings
         )
 

--- a/tests/expected_results/test_prepared_sens_dict_result_with_no_existing_schema.py
+++ b/tests/expected_results/test_prepared_sens_dict_result_with_no_existing_schema.py
@@ -1,0 +1,11 @@
+{
+	"dictionary": [
+		{
+			"schema":"not_exists_schema",
+			"table":"some_tbl",
+			"fields": {
+					"val":"'text const'"
+			}
+		},
+	],
+}

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1826,6 +1826,40 @@ class PGAnonViewDataUnitTest(unittest.IsolatedAsyncioTestCase, BasicUnitTest):
 
         passed_stages.append("test_04_view_data_null")
 
+    async def test_05_view_data_without_matched_rule(self):
+        self.assertTrue("init_env" in passed_stages)
+
+        prepared_sens_dict_file_name = self.get_test_expected_dict_path('test_prepared_sens_dict_result_with_no_existing_schema.py')
+        schema_name: str = 'schm_mask_ext_exclude_2'
+        table_name: str = 'card_numbers'
+
+        parser = Context.get_arg_parser()
+        args = parser.parse_args([
+                f"--db-host={params.test_db_host}",
+                f"--db-name={params.test_source_db}",
+                f"--db-user={params.test_db_user}",
+                f"--db-port={params.test_db_port}",
+                f"--db-user-password={params.test_db_user_password}",
+                "--mode=view-data",
+                f"--prepared-sens-dict-file={prepared_sens_dict_file_name}",
+                f"--schema-name={schema_name}",
+                f"--table-name={table_name}",
+                "--limit=10",
+                "--offset=0",
+                "--verbose=debug",
+                "--debug",
+        ])
+
+        context = MainRoutine(args).ctx  # Setup for context reusing only
+
+        executor = ViewDataMode(context)
+        res = await executor.run()
+        self.assertEqual(res.result_code, ResultCode.DONE)
+
+        self.assertTrue(len(executor.table.rows) > 0)
+
+        passed_stages.append("test_05_view_data_without_matched_rule")
+
 
 class PGAnonViewFieldsUnitTest(unittest.IsolatedAsyncioTestCase, BasicUnitTest):
 

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -7,8 +7,6 @@ import unittest
 from decimal import Decimal
 from typing import Dict, Set
 
-import asyncpg
-
 from pg_anon import MainRoutine
 from pg_anon.common.db_utils import get_scan_fields_count, create_connection
 from pg_anon.common.dto import PgAnonResult
@@ -166,11 +164,11 @@ class BasicUnitTest:
         await DBOperations.init_db(db_conn, params.test_target_db + "_8")  # for PGAnonValidateUnitTest 05
         await db_conn.close()
 
-        sourse_db_params = copy.copy(ctx.connection_params)
-        sourse_db_params.database = params.test_source_db
+        source_db_params = copy.copy(ctx.connection_params)
+        source_db_params.database = params.test_source_db
 
         print("============> Started init_env")
-        db_conn = await create_connection(sourse_db_params)
+        db_conn = await create_connection(source_db_params)
         await DBOperations.init_env(db_conn, "init_env.sql", params.test_scale)
         await db_conn.close()
         print("<============ Finished init_env")
@@ -219,8 +217,8 @@ class BasicUnitTest:
         db_conn = await create_connection(ctx.connection_params)
         await DBOperations.init_db_once(db_conn, params.test_source_db + "_stress")
 
-        sourse_db_params = copy.copy(ctx.connection_params)
-        sourse_db_params.database = params.test_source_db + "_stress"
+        source_db_params = copy.copy(ctx.connection_params)
+        source_db_params.database = params.test_source_db + "_stress"
 
         args = parser.parse_args(
             [
@@ -243,7 +241,7 @@ class BasicUnitTest:
         await db_conn.close()
         if len(schema_exists) == 0:
             print("============> Started init_stress_env")
-            db_conn = await create_connection(sourse_db_params)
+            db_conn = await create_connection(source_db_params)
             await DBOperations.init_env(
                 db_conn, "init_stress_env.sql", params.test_scale
             )


### PR DESCRIPTION
## Added:
- raw data collecting in `view-data` mode. It can be turned ON by `need_raw_data` argument in constructor
- check of schema `anon_funcs` exists before doing `create-dict` or `dump`
- counting rows method for all table in `view-data` mode
- CLI argument `--application-name-suffix` for comfortable automation. Influences on connection names and log names
 
## Updated:
### Critical:
- setup correct exit in case of failed queries
- fixed hash randomization by `hash()` in multiprocessing

### Other:
- `run_pg_anon` as entry point for pg_anon + setup starting pg_anon via entrypoint `run_pg_anon`
- made some refactoring in `view-data` mode
- fixed exception on `view-data` use case, when masked rule for table not found in prepared sensitive dict for selected table + added test for this case
- expanded logs and log names